### PR TITLE
Fix license designation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ npm run test:watch
 Open source software components distributed or made available in the Availity Materials are licensed to Company under the terms of the applicable open source license agreements, which may be found in text files included in the Availity Materials.
 
 ## License
-Copyright (c) 2016 Availity, LLC
+MIT


### PR DESCRIPTION
Not sure if I'm missing something or if this is the correct fix. The preceding clause lends some indication about the possible intent, but I definitely came close to not using this project when I saw `Copyright (c) 2016 Availity, LLC` under `## License` as opposed to the expected MIT / BSD or similar