### PR TITLE
chore(license): clarify/simplify license / update copyright years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Availity
+Copyright (c) 2016-present Availity, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ npm run test:watch
 Open source software components distributed or made available in the Availity Materials are licensed to Company under the terms of the applicable open source license agreements, which may be found in text files included in the Availity Materials.
 
 ## License
-Copyright (c) 2016 Availity, LLC
+[MIT](./LICENSE)


### PR DESCRIPTION
This clarifies the license section of the README to state the actual license and not the copyright. The project is still Copyright (c) Availity, LLC, that has not changed. I ahve updated the copyright years to include this year as changes have been made to the project this year.
MIT allows the original copyright owner to still maintain copyright, but allows other to use the project ("...as is, without warranty of any kind..." and such) as long as the license and copyright are included. It's the same MIT license as everyone else (there is only one dubbed MIT license AFAIK). If you can use react, then you can use this.

Closes #12 