### PR TITLE
Fix scroll to top on unlock

### DIFF
--- a/src/BlockUi.js
+++ b/src/BlockUi.js
@@ -35,7 +35,6 @@ class BlockUi extends Component {
         if (this.helper && this.helper.parentNode && this.helper.parentNode.contains
           && this.helper.parentNode.contains(safeActiveElement())) {
           this.focused = safeActiveElement();
-          // We cannot just blur to remove focus due to IE bug so we must manually move the focus somewhere else.
           // https://www.tjvantoll.com/2013/08/30/bugs-with-document-activeelement-in-internet-explorer/#blurring-the-body-switches-windows-in-ie9-and-ie10
           if (this.focused && this.focused !== document.body) {
             (window.setImmediate || setTimeout)(() => this.focused && this.focused.blur());

--- a/src/BlockUi.js
+++ b/src/BlockUi.js
@@ -38,7 +38,7 @@ class BlockUi extends Component {
           // We cannot just blur to remove focus due to IE bug so we must manually move the focus somewhere else.
           // https://www.tjvantoll.com/2013/08/30/bugs-with-document-activeelement-in-internet-explorer/#blurring-the-body-switches-windows-in-ie9-and-ie10
           if (this.focused && this.focused !== document.body) {
-            (window.setImmediate || setTimeout)(() => this.topFocus && this.topFocus.focus());
+            (window.setImmediate || setTimeout)(() => this.focused && this.focused.blur());
           }
         }
       } else {


### PR DESCRIPTION
Hi,

the react-block-ui component does scroll to top of the page when a section is unblocked.
You can reproduce it by only showing at part of "Focus / Keyboard Navigation" example (scroll so it show only the last two "Just try to trigger....".

When the component is unblocked, it will scroll to the top of that component (in chrome).
In our application, the component is very tall, so it will actually scroll to top.

I've fixed that. 
It is working in chrome and IE11 but I have not tested with older IE.
Do you want to keep support of these version anymore? In that case, I can do a test of the browser version...

Could you merge this in your futur master branch?

Best regards,

cbialobos