### PR TITLE
prevented loading symbol from being at the bottom of page or off the page because of height

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -35,7 +35,7 @@
 }
 .block-ui-message-container {
     position: absolute;
-    top: 50%;
+    top: 50vh;
     left: 0;
     right: 0;
     text-align: center;


### PR DESCRIPTION
using vh will ensure that the loading symbol is always in the center of the screen regardless of height and prevent cases shown in screenshot
![tooLow](https://user-images.githubusercontent.com/2576700/55735078-4cf53800-59e6-11e9-88d6-0b1183d71ed6.png)
