### PR TITLE
fix(BlockUI): allow tag to be components

### DIFF
--- a/__test__/BlockUi.spec.js
+++ b/__test__/BlockUi.spec.js
@@ -272,7 +272,7 @@ describe('BlockUi', function() {
         sinon.spy(instance.container, 'getBoundingClientRect');
         instance.keepInView();
         expect(instance.setState).to.not.have.been.called;
-        expect(instance.container.getBoundingClientRect).to.not.have.been.called;
+        expect(instance.container).to.not.exist;
       });
     });
     describe('when keepInView prop is falsey', () => {

--- a/__test__/BlockUi.spec.js
+++ b/__test__/BlockUi.spec.js
@@ -269,7 +269,6 @@ describe('BlockUi', function() {
         const wrapper = mount(<BlockUi keepInView><input /></BlockUi>);
         const instance = wrapper.instance();
         sinon.spy(instance, 'setState');
-        sinon.spy(instance.container, 'getBoundingClientRect');
         instance.keepInView();
         expect(instance.setState).to.not.have.been.called;
         expect(instance.container).to.not.exist;

--- a/src/BlockUi.js
+++ b/src/BlockUi.js
@@ -149,7 +149,7 @@ class BlockUi extends Component {
     const renderChilds = !blocking || renderChildren;
 
     return (
-      <Tag {...attributes} className={classes} aria-busy={blocking} ref={this.setContainer}>
+      <Tag {...attributes} className={classes} aria-busy={blocking}>
         {blocking &&
         <div tabIndex="0" onKeyUp={this.tabbedUpTop} onKeyDown={this.tabbedDownTop} ref={this.setTopFocus} />}
         {renderChilds && children}
@@ -160,7 +160,7 @@ class BlockUi extends Component {
           onKeyUp={this.tabbedUpBottom}
           onKeyDown={this.tabbedDownBottom}
         >
-          <div className="block-ui-overlay" />
+          <div className="block-ui-overlay" ref={this.setContainer} />
           <div className="block-ui-message-container"
             ref={this.setMessageContainer}
             style={{ top: keepInView ? this.state.top : undefined }}


### PR DESCRIPTION
remove ref from the wrapper element to allow wrapper to be any component (not just DOM elements)
the ref is now on the overlay which is the same height and width as the wrapper (per styling) allowing the keepInView logic to work the same.

fixes #8

Note: If we do want want to depend on styling (incase someone overrides the styles to make the overlay different), we can use the tab helpers which appear before and after the blocked content as mentioned in https://github.com/Availity/react-block-ui/issues/8#issuecomment-473566646. If this is the case, a new PR can be made.