### PR TITLE
fix(Tag): account for forwardRef objects

### DIFF
--- a/src/BlockUi.js
+++ b/src/BlockUi.js
@@ -196,6 +196,7 @@ BlockUi.propTypes = {
   tag: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func,
+    PropTypes.shape({ $$typeof: PropTypes.symbol, render: PropTypes.func }),
   ]),
 };
 BlockUi.defaultProps = defaultProps;


### PR DESCRIPTION
This or bump prop-types to a min version of 15.7.0 where they introduce `.elementType`