### PR TITLE
Allow to use npm 3 and higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "dist/reactblockui.d.ts",
   "engines": {
     "node": ">= 5.0.0",
-    "npm": "^3.0.0"
+    "npm": ">= 3.0.0"
   },
   "scripts": {
     "coveralls": "coveralls < ./__test__/coverage/lcov.info",


### PR DESCRIPTION
This is a problem on projects that have also added engine restrictions. We keep getting 
npm ERR! notsup Unsupported engine for react-block-ui@1.3.2: wanted: {"node":">= 5.0.0","npm":"^3.0.0"} (current: {"node":"10.16.3","npm":"6.9.0"})
npm ERR! notsup Not compatible with your version of node/npm: react-block-ui@1.3.2
npm ERR! notsup Not compatible with your version of node/npm: react-block-ui@1.3.2
npm ERR! notsup Required: {"node":">= 5.0.0","npm":"^3.0.0"}
npm ERR! notsup Actual:   {"npm":"6.9.0","node":"10.16.3"}