### PR TITLE
chore: update travis node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 6
+  - 12
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Change version of node used by travis to 12 (current LTS).